### PR TITLE
Allow to change songs on the paused player

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     * Plays the most recently paused media player if none are currently playing
     * Pauses all media players if one or more are currently playing
 * Next/Previous control
-    * Advances to the next or previous song on the media player that is currently playing.
+    * Advances to the next or previous song on the media player that is currently playing, or on the most recently _used_ media player if all are paused.
 
 It accomplishes this by keeping track of the playback status of all MPRIS2 players currently active in a user's session, alleviating problems such as only being able to have keybindings for a specific player, having all players start playing at once, etc.
 

--- a/mpris2controller
+++ b/mpris2controller
@@ -200,12 +200,18 @@ class Controller(dbus.service.Object):
     @dbus.service.method(dbus_interface=MY_INTERFACE)
     def Next(self):
         log.info('Method call for Next.')
-        self.call_on_one_playing('Next')
+        if len(self.playing) > 0:
+            self.call_on_one_playing('Next')
+        else:
+            self.call_on_head_not_playing('Next')
 
     @dbus.service.method(dbus_interface=MY_INTERFACE)
     def Previous(self):
         log.info('Method call for Previous.')
-        self.call_on_one_playing('Previous')
+        if len(self.playing) > 0:
+            self.call_on_one_playing('Previous')
+        else:
+            self.call_on_head_not_playing('Previous')
 
 
 def is_daemon_up():


### PR DESCRIPTION
De facto standard is that when the media player is paused, "previous"
and "next" buttons are still functional.